### PR TITLE
better example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const message = {
   "host": "www1",
   "short_message": "Short message",
   "full_message": "Backtrace here\n\nmore stuff",
-  "timestamp": 1291899928.412,
+  "timestamp": Date.now() / 1000,
   "level": 1,
   "facility": "payment-backend",
   "file": "/var/www/somefile.rb",


### PR DESCRIPTION
The "full message" example was using a fixed date/timestamp from 2010. While this works, it does not show up in the default Graylog stream views as it is from the distant past, which made me think that this module was broken or not sending the message. Fix this by using the current timestamp.