### PR TITLE
unref the socket

### DIFF
--- a/gelf.js
+++ b/gelf.js
@@ -37,6 +37,7 @@ class Gelf extends EventEmitter {
 
   openSocket () {
     const client = dgram.createSocket('udp4')
+    client.unref();
     return client
   }
 

--- a/gelf.js
+++ b/gelf.js
@@ -37,7 +37,7 @@ class Gelf extends EventEmitter {
 
   openSocket () {
     const client = dgram.createSocket('udp4')
-    client.unref();
+    client.unref()
     return client
   }
 


### PR DESCRIPTION
`unref()` the UDP socket so this module doesn't prevent an app from ending. Although you can call `closeSocket` to do the same thing, why not let this module clean up after itself.